### PR TITLE
Fixing some contrast issues of the text in darkmode.

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ html {
 }
 
 body {
-  font-family: "Poppins", sans-serif;
+  font-family: 'Poppins', sans-serif;
 }
 
 #preloader {
@@ -26,7 +26,7 @@ body {
   /* centers the loading animation horizontally one the screen */
   top: 50%;
   /* centers the loading animation vertically one the screen */
-  background-image: url("book.gif");
+  background-image: url('book.gif');
   z-index: 9999;
   /* path to your loading animation */
   background-repeat: no-repeat;
@@ -817,4 +817,18 @@ body {
 
 .darkmode-toggle {
   z-index: 1031;
+}
+
+/* Fixing Darkmode Text Contrast */
+
+body.darkmode--activated .header-details h1,
+body.darkmode--activated .video-details h2 {
+  color: whitesmoke;
+}
+
+body.darkmode--activated .header-details p,
+body.darkmode--activated .video-details p,
+body.darkmode--activated .testimonial,
+body.darkmode--activated .overview {
+  color: rgb(209, 209, 209);
 }


### PR DESCRIPTION
Adding special CSS rules that turn the text lighter only when in dark
mode.

Currently, the website doesn't have a good color contrast while in darkmode.
![before](https://user-images.githubusercontent.com/39182614/135597153-018c399e-7e74-4bd4-a790-ef183ac8bac5.png)

This PR fixes the color in darkmode.
![after](https://user-images.githubusercontent.com/39182614/135597199-583d7ba9-7c55-4f65-acfd-6ac0a1e102f6.png)

(More text is fixed at the bottom of the website in the same way that is shown in the pictures).